### PR TITLE
Add call to Distinct() so that extension doesn't try to remove the sa…

### DIFF
--- a/src/NuGetReferenceSwitcher.Presentation/ViewModels/MainDialogModel.cs
+++ b/src/NuGetReferenceSwitcher.Presentation/ViewModels/MainDialogModel.cs
@@ -241,7 +241,7 @@ namespace NuGetReferenceSwitcher.Presentation.ViewModels
                 var pathsOfProjectsToRemove = projectsToDelete.Select(p => p.Path);
                 var projectBuildOrder = ProjectDependencyResolver.GetBuildOrder(pathsOfProjectsToRemove).ToList();
                 var orderedProjectsToRemove = projectsToDelete
-                    .OrderByDescending(p => projectBuildOrder.IndexOf(p.Path)).ToList();
+                    .OrderByDescending(p => projectBuildOrder.IndexOf(p.Path)).Distinct().ToList();
 
                 foreach (var project in orderedProjectsToRemove)
                 {


### PR DESCRIPTION
…me project twice which results in an exception.

Not sure if there is another problem that resulted in getting 66 instances of ProjectModel in the projectsToDelete collection but either way, this was a safe way to make sure I only removed each project once. 