### PR TITLE
Fix blocked input after window is closed #12

### DIFF
--- a/src/NuGetReferenceSwitcher.Presentation/ViewModels/MainDialogModel.cs
+++ b/src/NuGetReferenceSwitcher.Presentation/ViewModels/MainDialogModel.cs
@@ -145,9 +145,8 @@ namespace NuGetReferenceSwitcher.Presentation.ViewModels
                         }
                     }
 
-                    // TODO: Save project
-                    //if (SaveProjects)
-                    //    project.Save();
+                    if (SaveProjects)
+                        project.Save();
 
                     if (!string.IsNullOrEmpty(nuGetReferenceTransformationsForProject))
                     {
@@ -191,9 +190,8 @@ namespace NuGetReferenceSwitcher.Presentation.ViewModels
                         }
                     }
 
-                    // TODO: Save project
-                    //if (SaveProjects)
-                    //    project.Save();
+                    if (SaveProjects)
+                        project.Save();
 
                     project.DeleteConfigurationFile();
                 }

--- a/src/NuGetReferenceSwitcher.Presentation/Views/MainDialog.xaml
+++ b/src/NuGetReferenceSwitcher.Presentation/Views/MainDialog.xaml
@@ -1,9 +1,10 @@
-﻿<Window x:Class="NuGetReferenceSwitcher.Presentation.Views.MainDialog"
+﻿<PlatformUi:DialogWindow x:Class="NuGetReferenceSwitcher.Presentation.Views.MainDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:converters="clr-namespace:MyToolkit.Converters;assembly=MyToolkit.Extended"
         xmlns:viewModels="clr-namespace:NuGetReferenceSwitcher.Presentation.ViewModels"
-        xmlns:converters1="clr-namespace:NuGetReferenceSwitcher.Presentation.Converters"
+        xmlns:converters1="clr-namespace:NuGetReferenceSwitcher.Presentation.Converters" 
+        xmlns:PlatformUi="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.12.0"
         Title="Switch NuGet and Project references" 
         Height="700" Width="800" ResizeMode="CanResizeWithGrip"
         WindowStartupLocation="CenterScreen">
@@ -171,4 +172,5 @@
             </TabItem>
         </TabControl>
     </Grid>
-</Window>
+</PlatformUi:DialogWindow>
+

--- a/src/NuGetReferenceSwitcher.Presentation/Views/MainDialog.xaml.cs
+++ b/src/NuGetReferenceSwitcher.Presentation/Views/MainDialog.xaml.cs
@@ -13,6 +13,9 @@ using System.Windows.Documents;
 using System.Windows.Forms;
 using System.Windows.Input;
 using EnvDTE;
+
+using Microsoft.VisualStudio.PlatformUI;
+
 using MyToolkit.Collections;
 using MyToolkit.Mvvm;
 using NuGetReferenceSwitcher.Presentation.Models;
@@ -24,7 +27,7 @@ using Window = System.Windows.Window;
 namespace NuGetReferenceSwitcher.Presentation.Views
 {
     /// <summary>Interaction logic for MainDialog.xaml </summary>
-    public partial class MainDialog : Window
+    public partial class MainDialog : DialogWindow
     {
         private OpenFileDialog _dlg;
         

--- a/src/NuGetReferenceSwitcher.VS17/NuGetReferenceSwitcherPackage.cs
+++ b/src/NuGetReferenceSwitcher.VS17/NuGetReferenceSwitcherPackage.cs
@@ -63,7 +63,7 @@ namespace RicoSuter.NuGetReferenceSwitcher
                     var window = new MainDialog(application, GetType().Assembly);
                     var helper = new WindowInteropHelper(window);
                     helper.Owner = (IntPtr)application.MainWindow.HWnd;
-                    window.ShowDialog();
+                    window.ShowModal();
                 }
             }
         }


### PR DESCRIPTION
Derive from Microsoft.VisualStudio.PlatformUI.DialogWindow instead of System.Windows.Window.

Also reenabled auto-save. Does not work like expected (no projects are actually saved) - maybe someone can help?

2017 compiles and works fine, could not test others.