### PR TITLE
Feature/load test project

### DIFF
--- a/src/NuGetReferenceSwitcher.Presentation/Models/FromNuGetToProjectTransformation.cs
+++ b/src/NuGetReferenceSwitcher.Presentation/Models/FromNuGetToProjectTransformation.cs
@@ -46,6 +46,12 @@ namespace NuGetReferenceSwitcher.Presentation.Models
                     ToProjectPath = swi.FromProjectPath;
                 else
                     ToProject = targetProject;
+
+                var targetTestProject = projects.FirstOrDefault(p => p.Path == swi.FromTestProjectPath);
+                if (targetTestProject == null)
+                    ToTestProjectPath = swi.FromTestProjectPath;
+                else
+                    ToTestProject = targetProject;
             }
             else
                 SelectedMode = NuGetToProjectMode.Deactivated;

--- a/src/NuGetReferenceSwitcher.Presentation/Models/FromNuGetToProjectTransformation.cs
+++ b/src/NuGetReferenceSwitcher.Presentation/Models/FromNuGetToProjectTransformation.cs
@@ -23,7 +23,9 @@ namespace NuGetReferenceSwitcher.Presentation.Models
     public class FromNuGetToProjectTransformation : ObservableObject
     {
         private string _toProjectPath;
+        private string _toTestProjectPath;
         private ProjectModel _toProject;
+        private ProjectModel _toTestProject;
 
         /// <summary>Initializes a new instance of the <see cref="FromNuGetToProjectTransformation"/> class. </summary>
         /// <param name="projects">The projects. </param>
@@ -92,6 +94,36 @@ namespace NuGetReferenceSwitcher.Presentation.Models
                         SelectedMode = NuGetToProjectMode.ProjectPath;
                     else
                         SelectedMode = NuGetToProjectMode.Project;
+                }
+            }
+        }
+
+        public ProjectModel ToTestProject
+        {
+            get { return _toTestProject; }
+            set
+            {
+                if (Set(ref _toTestProject, value))
+                {
+                    if (_toTestProject == null)
+                        SelectedMode = NuGetToProjectMode.ProjectPath;
+                    else
+                        SelectedMode = NuGetToProjectMode.Project;
+                }
+            }
+        }
+
+        public string ToTestProjectPath
+        {
+            get { return _toTestProjectPath; }
+            set
+            {
+                if (Set(ref _toTestProjectPath, value))
+                {
+                    if (_toTestProjectPath == null)
+                        SelectedMode = NuGetToProjectMode.Project;
+                    else
+                        SelectedMode = NuGetToProjectMode.ProjectPath;
                 }
             }
         }

--- a/src/NuGetReferenceSwitcher.Presentation/Models/FromProjectToNuGetTransformation.cs
+++ b/src/NuGetReferenceSwitcher.Presentation/Models/FromProjectToNuGetTransformation.cs
@@ -21,5 +21,8 @@ namespace NuGetReferenceSwitcher.Presentation.Models
 
         /// <summary>Gets or sets the test project name. </summary>
         public string FromTestProjectName { get; set; }
+
+        /// <summary>Gets or sets the test project path. </summary>
+        public string FromTestProjectPath { get; set; }
     }
 }

--- a/src/NuGetReferenceSwitcher.Presentation/Models/FromProjectToNuGetTransformation.cs
+++ b/src/NuGetReferenceSwitcher.Presentation/Models/FromProjectToNuGetTransformation.cs
@@ -18,5 +18,8 @@ namespace NuGetReferenceSwitcher.Presentation.Models
 
         /// <summary>Gets or sets the NuGet assembly path name to switch to. </summary>
         public string ToAssemblyPath { get; set; }
+
+        /// <summary>Gets or sets the test project name. </summary>
+        public string FromTestProjectName { get; set; }
     }
 }

--- a/src/NuGetReferenceSwitcher.Presentation/Models/ProjectModel.cs
+++ b/src/NuGetReferenceSwitcher.Presentation/Models/ProjectModel.cs
@@ -144,7 +144,7 @@ namespace NuGetReferenceSwitcher.Presentation.Models
             {
                 var lines = File.ReadAllLines(configurationPath)
                     .Select(l => l.Split('\t'))
-                    .Where(l => l.Length == 4).ToArray();
+                    .Where(l => l.Length == 5).ToArray();
 
                 
 
@@ -153,7 +153,8 @@ namespace NuGetReferenceSwitcher.Presentation.Models
                         FromProjectName = line[0],
                         FromProjectPath = PathUtilities.MakeAbsolute(line[1], configurationPath),
                         ToAssemblyPath = PathUtilities.MakeAbsolute(line[2], configurationPath),
-                        FromTestProjectName = line[3]
+                        FromTestProjectName = line[3],
+                        FromTestProjectPath = PathUtilities.MakeAbsolute(line[4], configurationPath),
                     });
             }
             return list;

--- a/src/NuGetReferenceSwitcher.Presentation/Models/ProjectModel.cs
+++ b/src/NuGetReferenceSwitcher.Presentation/Models/ProjectModel.cs
@@ -144,7 +144,7 @@ namespace NuGetReferenceSwitcher.Presentation.Models
             {
                 var lines = File.ReadAllLines(configurationPath)
                     .Select(l => l.Split('\t'))
-                    .Where(l => l.Length == 3).ToArray();
+                    .Where(l => l.Length == 4).ToArray();
 
                 
 
@@ -152,7 +152,8 @@ namespace NuGetReferenceSwitcher.Presentation.Models
                     list.Add(new FromProjectToNuGetTransformation {
                         FromProjectName = line[0],
                         FromProjectPath = PathUtilities.MakeAbsolute(line[1], configurationPath),
-                        ToAssemblyPath = PathUtilities.MakeAbsolute(line[2], configurationPath)
+                        ToAssemblyPath = PathUtilities.MakeAbsolute(line[2], configurationPath),
+                        FromTestProjectName = line[3]
                     });
             }
             return list;

--- a/src/NuGetReferenceSwitcher.Presentation/ViewModels/MainDialogModel.cs
+++ b/src/NuGetReferenceSwitcher.Presentation/ViewModels/MainDialogModel.cs
@@ -160,6 +160,8 @@ namespace NuGetReferenceSwitcher.Presentation.ViewModels
                         File.AppendAllText(project.CurrentConfigurationPath, nuGetReferenceTransformationsForProject);
                     }
                 }
+                if (!Application.Solution.Saved)
+                    Application.Solution.SaveAs(Application.Solution.FullName);
             }, token));
         }
 
@@ -206,6 +208,8 @@ namespace NuGetReferenceSwitcher.Presentation.ViewModels
                 }
 
                 RemoveProjectsFromSolution(projectsToRemove);
+                if (!Application.Solution.Saved)
+                    Application.Solution.SaveAs(Application.Solution.FullName);
             }, token));
         }
 

--- a/src/NuGetReferenceSwitcher.Presentation/ViewModels/MainDialogModel.cs
+++ b/src/NuGetReferenceSwitcher.Presentation/ViewModels/MainDialogModel.cs
@@ -139,6 +139,8 @@ namespace NuGetReferenceSwitcher.Presentation.ViewModels
                                     "\t" +
                                     assemblyToProjectSwitch.ToTestProject.Name +
                                     "\t" +
+                                    PathUtilities.MakeRelative(assemblyToProjectSwitch.ToTestProject.Path,
+                                        project.CurrentConfigurationPath) +
                                     "\n";
                             }
                             else
@@ -258,8 +260,6 @@ namespace NuGetReferenceSwitcher.Presentation.ViewModels
                     var myProject = new ProjectModel((VSProject)project.Object, Application);
                     fromNuGetToProjectTransformation.ToTestProject = myProject;
                 }
-                else
-                    MessageBox.Show("The project '" + fromNuGetToProjectTransformation.ToTestProjectPath + "' could not be found. (ignored)", "Project not found", MessageBoxButton.OK, MessageBoxImage.Stop);
             }
         }
 

--- a/src/NuGetReferenceSwitcher.Presentation/Views/MainDialog.xaml
+++ b/src/NuGetReferenceSwitcher.Presentation/Views/MainDialog.xaml
@@ -74,10 +74,7 @@
                                                            Visibility="{Binding ToTestProjectPath, Converter={StaticResource VisibilityConverter}}" />
                                             </StackPanel>
                                             <StackPanel Visibility="{Binding SelectedMode, Mode=OneWay, ConverterParameter='Project', Converter={StaticResource NuGetToProjectModeConverter}}">
-                                                    <ComboBox ItemsSource="{Binding Project, Source={StaticResource ViewModel}}"
-                                                              SelectedItem="{Binding ToTestProject, Mode=TwoWay}"
-                                                              DisplayMemberPath="Name" />
-                                                </StackPanel>
+                                                    </StackPanel>
                                         </StackPanel>
                                     </StackPanel>
                                 </DataTemplate>

--- a/src/NuGetReferenceSwitcher.Presentation/Views/MainDialog.xaml
+++ b/src/NuGetReferenceSwitcher.Presentation/Views/MainDialog.xaml
@@ -68,6 +68,16 @@
                                                           SelectedItem="{Binding ToProject, Mode=TwoWay}"
                                                           DisplayMemberPath="Name" />
                                             </StackPanel>
+                                            <StackPanel Visibility="{Binding SelectedMode, Mode=OneWay, ConverterParameter='ProjectPath', Converter={StaticResource NuGetToProjectModeConverter}}">
+                                                <Button Content="Select a Test Project to add" Click="OnSelectTestProjectFile" Tag="{Binding}" />
+                                                <TextBlock Text="{Binding ToTestProjectPath}" TextWrapping="Wrap" Margin="0,4,0,0"
+                                                           Visibility="{Binding ToTestProjectPath, Converter={StaticResource VisibilityConverter}}" />
+                                            </StackPanel>
+                                            <StackPanel Visibility="{Binding SelectedMode, Mode=OneWay, ConverterParameter='Project', Converter={StaticResource NuGetToProjectModeConverter}}">
+                                                    <ComboBox ItemsSource="{Binding Project, Source={StaticResource ViewModel}}"
+                                                              SelectedItem="{Binding ToTestProject, Mode=TwoWay}"
+                                                              DisplayMemberPath="Name" />
+                                                </StackPanel>
                                         </StackPanel>
                                     </StackPanel>
                                 </DataTemplate>

--- a/src/NuGetReferenceSwitcher.Presentation/Views/MainDialog.xaml.cs
+++ b/src/NuGetReferenceSwitcher.Presentation/Views/MainDialog.xaml.cs
@@ -102,5 +102,24 @@ namespace NuGetReferenceSwitcher.Presentation.Views
             if (_dlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
                 fntpSwitch.ToProjectPath = _dlg.FileName;
         }
+
+        private void OnSelectTestProjectFile(object sender, RoutedEventArgs e)
+        {
+            var fntpSwitch = (FromNuGetToProjectTransformation)((Button)sender).Tag;
+            if (_dlg == null)
+            {
+                _dlg = new OpenFileDialog();
+                _dlg.Filter = "CSharp Projects (*.csproj)|*.csproj|VB.NET Projects (*.vbproj)|*.vbproj";
+
+                // switch to VB if any VB project is already referenced
+                if (Model.Transformations.Any(t => t.ToTestProjectPath != null && t.ToTestProjectPath.EndsWith(".vbproj", System.StringComparison.OrdinalIgnoreCase)))
+                    _dlg.FilterIndex = 2;
+            }
+
+            _dlg.Title = string.Format("Select Project for '{0}'", fntpSwitch.FromAssemblyName);
+
+            if (_dlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                fntpSwitch.ToTestProjectPath = _dlg.FileName;
+        }
     }
 }


### PR DESCRIPTION
I've added a fix that save automatically all the project and the solution so you don't need to save it manually everytime you are switching.

Added the possibility to load also an extra test project (this will just add the extra project when switching to project reference and remove it when switching to Nugget reference)